### PR TITLE
Support Xcode 26

### DIFF
--- a/OmniBLETests/Driver/Comm/message/MessagePacketTests.swift
+++ b/OmniBLETests/Driver/Comm/message/MessagePacketTests.swift
@@ -49,7 +49,7 @@ class MessagePacketTests: XCTestCase {
                                 tfs: false,
                                 version: 0)
         
-        assert(msg.payload.bytes.toHexString() == payloadString)
+        assert(msg.payload.hexadecimalString == payloadString)
     }
-
 }
+


### PR DESCRIPTION
Xcode 26 replaces `Data.bytes` from `[UInt8]` to `[RawSpan]`. This mirrors what's in `LoopKit/OmniBLE`.